### PR TITLE
feat: Implement API rate limiting for AlpacaService

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "colorama",
     "alpaca-trade-api",
     "python-dotenv", # For managing API keys
+    "ratelimit",
 ]
 requires-python = ">=3.8"
 readme = "README.md"


### PR DESCRIPTION
- Added `ratelimit` library to dependencies.
- Applied rate limits (200/min, 10/sec burst) to Alpaca API calls in `AlpacaService`.
- Handled `RateLimitException` to return an error message.
- Added tests to verify rate limiting behavior, including mocking time for per-second limits.